### PR TITLE
Make default_text point to chosen.default_text so the reference is kept

### DIFF
--- a/chosen.js
+++ b/chosen.js
@@ -32,7 +32,7 @@
         require: '?ngModel',
         terminal: true,
         link: function(scope, element, attr, ngModel) {
-          var chosen, defaultText, disableWithMessage, empty, initOrUpdate, match, options, origRender, removeEmptyMessage, startLoading, stopLoading, valuesExpr, viewWatch;
+          var chosen, disableWithMessage, empty, initOrUpdate, match, options, origRender, removeEmptyMessage, startLoading, stopLoading, valuesExpr, viewWatch;
           element.addClass('localytics-chosen');
           options = scope.$eval(attr.chosen) || {};
           angular.forEach(attr, function(value, key) {
@@ -47,19 +47,17 @@
             return element.removeClass('loading').attr('disabled', false).trigger('chosen:updated');
           };
           chosen = null;
-          defaultText = null;
           empty = false;
           initOrUpdate = function() {
             if (chosen) {
               return element.trigger('chosen:updated');
             } else {
-              chosen = element.chosen(options).data('chosen');
-              return defaultText = chosen.default_text;
+              return chosen = element.chosen(options).data('chosen');
             }
           };
           removeEmptyMessage = function() {
             empty = false;
-            return element.attr('data-placeholder', defaultText);
+            return element.attr('data-placeholder', chosen.default_text);
           };
           disableWithMessage = function() {
             empty = true;

--- a/src/chosen.coffee
+++ b/src/chosen.coffee
@@ -49,7 +49,6 @@ angular.module('localytics.directives').directive 'chosen', ['$timeout', ($timeo
     stopLoading = -> element.removeClass('loading').attr('disabled', false).trigger('chosen:updated')
 
     chosen = null
-    defaultText = null
     empty = false
 
     initOrUpdate = ->
@@ -57,12 +56,11 @@ angular.module('localytics.directives').directive 'chosen', ['$timeout', ($timeo
         element.trigger('chosen:updated')
       else
         chosen = element.chosen(options).data('chosen')
-        defaultText = chosen.default_text
 
     # Use Chosen's placeholder or no results found text depending on whether there are options available
     removeEmptyMessage = ->
       empty = false
-      element.attr('data-placeholder', defaultText)
+      element.attr('data-placeholder', chosen.default_text)
 
     disableWithMessage = ->
       empty = true


### PR DESCRIPTION
This fixes an issue if `default text` has been updated (for example, translation language changed).