### PR TITLE
fixes #155, angular 1.4.9+ (including 1.5) compatibility. 

### DIFF
--- a/chosen.js
+++ b/chosen.js
@@ -30,7 +30,7 @@
       return {
         restrict: 'A',
         require: '?ngModel',
-        terminal: true,
+        priority: 1,
         link: function(scope, element, attr, ngModel) {
           var chosen, defaultText, disableWithMessage, empty, initOrUpdate, match, options, origRender, removeEmptyMessage, startLoading, stopLoading, valuesExpr, viewWatch;
           element.addClass('localytics-chosen');
@@ -66,7 +66,11 @@
             return element.attr('data-placeholder', chosen.results_none_found).attr('disabled', true).trigger('chosen:updated');
           };
           if (ngModel) {
-            initOrUpdate();
+            origRender = ngModel.$render;
+            ngModel.$render = function() {
+              origRender();
+              return initOrUpdate();
+            };
             if (attr.multiple) {
               viewWatch = function() {
                 return ngModel.$viewValue;

--- a/chosen.js
+++ b/chosen.js
@@ -66,11 +66,7 @@
             return element.attr('data-placeholder', chosen.results_none_found).attr('disabled', true).trigger('chosen:updated');
           };
           if (ngModel) {
-            origRender = ngModel.$render;
-            ngModel.$render = function() {
-              origRender();
-              return initOrUpdate();
-            };
+            initOrUpdate();
             if (attr.multiple) {
               viewWatch = function() {
                 return ngModel.$viewValue;

--- a/src/chosen.coffee
+++ b/src/chosen.coffee
@@ -70,10 +70,7 @@ angular.module('localytics.directives').directive 'chosen', ['$timeout', ($timeo
 
     # Watch the underlying ngModel for updates and trigger an update when they occur.
     if ngModel
-      origRender = ngModel.$render
-      ngModel.$render = ->
-        origRender()
-        initOrUpdate()
+      initOrUpdate()
 
       # This is basically taken from angular ngOptions source.  ngModel watches reference, not value,
       # so when values are added or removed from array ngModels, $render won't be fired.

--- a/src/chosen.coffee
+++ b/src/chosen.coffee
@@ -33,7 +33,7 @@ angular.module('localytics.directives').directive 'chosen', ['$timeout', ($timeo
 
   restrict: 'A'
   require: '?ngModel'
-  terminal: true
+  priority: 1,
   link: (scope, element, attr, ngModel) ->
 
     element.addClass('localytics-chosen')
@@ -70,7 +70,10 @@ angular.module('localytics.directives').directive 'chosen', ['$timeout', ($timeo
 
     # Watch the underlying ngModel for updates and trigger an update when they occur.
     if ngModel
-      initOrUpdate()
+      origRender = ngModel.$render
+      ngModel.$render = ->
+        origRender()
+        initOrUpdate()
 
       # This is basically taken from angular ngOptions source.  ngModel watches reference, not value,
       # so when values are added or removed from array ngModels, $render won't be fired.


### PR DESCRIPTION
With 1.4.9, ngModel.$render gets redefined in the postLink function