### PR TITLE
Remove terminal: true, replace with priority: 1

### DIFF
--- a/src/chosen.coffee
+++ b/src/chosen.coffee
@@ -33,7 +33,7 @@ angular.module('localytics.directives').directive 'chosen', ['$timeout', ($timeo
 
   restrict: 'A'
   require: '?ngModel'
-  terminal: true
+  priority: 1
   link: (scope, element, attr, ngModel) ->
 
     element.addClass('localytics-chosen')


### PR DESCRIPTION
This fixes angular 1.5 compability issues. Original idea by @akotlar, just making the pull request. Seems a better solution to #158 than my initial approach.